### PR TITLE
Update URLs, support cycleway:both tagging

### DIFF
--- a/api/OpenStreetMap.js
+++ b/api/OpenStreetMap.js
@@ -14,9 +14,7 @@ OpenLayers.Layer.OSM.Mapnik = OpenLayers.Class(OpenLayers.Layer.OSM, {
      */
     initialize: function(name, options) {
         var url = [
-            "http://a.tile.openstreetmap.org/${z}/${x}/${y}.png",
-            "http://b.tile.openstreetmap.org/${z}/${x}/${y}.png",
-            "http://c.tile.openstreetmap.org/${z}/${x}/${y}.png"
+            "http://tile.openstreetmap.org/${z}/${x}/${y}.png"
         ];
         options = OpenLayers.Util.extend({
             numZoomLevels: 20,

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@ var browser = "";
 		var QURL = "http://mijndev.openstreetmap.nl/~ligfietser/fiets/api/interpreter/";
 		}
 		else{
-			var QURL = "http://overpass-api.de/api/interpreter/"; //default
+			var QURL = "https://overpass-api.de/api/interpreter/"; //default
 		}
 // standaard positie/zoom		
       var lat = 52.15;

--- a/js_source/layerdef.js
+++ b/js_source/layerdef.js
@@ -32,10 +32,72 @@
 			
 			make_layer(QURL + "?data=(way[cycleway~'track'][highway!=cycleway](bbox);node(w);way['cycleway:right'~'track'](bbox);node(w);way['cycleway:left'~'track'](bbox);node(w););out+skel;", "#ff6541",name="#l#cycleway=track", 6, false,"@0.9"),
 			
-         	make_layer(QURL +
-            "?data=(way[cycleway=lane](bbox);node(w);way[cycleway=opposite_lane](bbox);node(w);way['cycleway:right'=opposite_lane](bbox);node(w);way['cycleway:left'=opposite_lane](bbox);node(w);way['cycleway:left'=lane](bbox);node(w);way['cycleway:right'=lane](bbox);node(w);way['cycleway:left'=shoulder](bbox);node(w);way['cycleway:left'=shoulder](bbox);node(w);way['cycleway:right'=shoulder](bbox);node(w););out+skel;","#ff6541",name="#dl#cycleway=lane", 6, false,"6 10@0.9"),
+			make_layer(
+				QURL + "?data=" + 
+				`(
+					way['cycleway:right'=opposite_lane](bbox);
+					node(w);
 
-			make_layer(QURL + "?data=(way[cycleway='shared_lane'](bbox);node(w);way[cycleway=share_busway](bbox);node(w);way[cycleway=opposite_share_busway](bbox);node(w);way['cycleway:left'='shared_lane'](bbox);node(w);way['cycleway:right'='shared_lane'](bbox);node(w););out+skel;","red",name="#d#cycleway=shared_lane", 2, false,"6 10"),
+					way['cycleway:left'=opposite_lane](bbox);
+					node(w);
+
+					way['cycleway:both'=opposite_lane](bbox);
+					node(w);
+					way[cycleway=opposite_lane](bbox);
+					node(w);
+
+
+					way['cycleway:left'=lane](bbox);
+					node(w);
+
+					way['cycleway:right'=lane](bbox);
+					node(w);
+
+					way['cycleway:both'=lane](bbox);
+					node(w);
+					way[cycleway=lane](bbox);
+					node(w);
+
+
+					way['cycleway:left'=shoulder](bbox);
+					node(w);
+
+					way['cycleway:right'=shoulder](bbox);
+					node(w);
+
+					way['cycleway:both'=shoulder](bbox);
+					node(w);
+					way[cycleway=shoulder](bbox);
+					node(w);
+				);
+				out+skel;`,
+				"#ff6541",name="#dl#cycleway=lane", 6, false,"6 10@0.9"
+			),
+
+			make_layer(
+				QURL + "?data=" +
+				`(
+					way[cycleway='shared_lane'](bbox);
+					node(w);
+
+					way[cycleway=share_busway](bbox);
+					node(w);
+
+					way[cycleway=opposite_share_busway](bbox);
+					node(w);
+
+					way['cycleway:left'='shared_lane'](bbox);
+					node(w);
+
+					way['cycleway:right'='shared_lane'](bbox);
+					node(w);
+
+					way['cycleway:both'='shared_lane'](bbox);
+					node(w);
+				);
+				out+skel;`,
+				"red",name="#d#cycleway=shared_lane", 2, false,"6 10"
+			),
           	
 		
 			//kenmerken met oneway


### PR DESCRIPTION
In my area (Pittsburgh, PA, US), some usage of cycleway:both is seen. This led to false alarm "holes" in the cycling network when viewing in the map. I think this tagging is from Streetcomplete and just a general direction we're going with the :left, :right, :both, (null) tagging. `*:both=` seems to be preferred over `*=`, at least with `sidewalk:*=separate` and apparently `cycleway:*=*` if we're going off of Streetcomplete's schema. The main change I've done is just some edits to pick up `*:both` with some common `cycleway=` layers.

Changes:
* Fix insecure/mixed content warning (http vs. https) when hosting map over https
* Mapnik: Use preferred OpenStreetMap tile server (see: https://github.com/openstreetmap/operations/issues/737)
* cycleway:both support for shared_lane
* cycleway:both support for lane, shoulder, etc

Deployment at https://ctrlaltf2.github.io/Bicycle_Tags_Map/ (based on my staging branch though, so might change by the time you get this).